### PR TITLE
Add disk labels and interval config

### DIFF
--- a/smartmon.py
+++ b/smartmon.py
@@ -10,6 +10,7 @@ class SmartMon(AgentCheck):
 
     def check(self, instance):
         devlist = DeviceList()
+        labels = instance.get("labels")
 
         for dev in range(len(devlist.devices)):
             device = devlist.devices[dev]
@@ -19,6 +20,9 @@ class SmartMon(AgentCheck):
                     f"serial:{device.serial}",
                     f"model:{device.model}",
                     f"is_ssd:{device.is_ssd}",]
+
+            if labels is not None and device.name in labels:
+                tags.append(f"label:{labels[device.name]}")
 
             # overall pass/fail check
             self.gauge("smartmon.Assessment", int(device.assessment == 'PASS'), tags=tags)

--- a/smartmon.yaml
+++ b/smartmon.yaml
@@ -1,4 +1,10 @@
 init_config:
 
 instances:
-    [{}]
+  -
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+
+    min_collection_interval: 300

--- a/smartmon.yaml
+++ b/smartmon.yaml
@@ -8,3 +8,12 @@ instances:
     #
 
     min_collection_interval: 300
+
+    ## @param labels - list of strings - optional
+    ## A list of labels mapped to the device names 
+    ##
+    #
+    # labels:
+    #   sda: root
+    #   sdb: opt
+    #   sdc: data


### PR DESCRIPTION
Labels allow adding readable names for each drive.
Default check interval is 15 sec, that make no sense for smart checks.